### PR TITLE
Add excepton catcher to filter_images()

### DIFF
--- a/image_download.py
+++ b/image_download.py
@@ -49,10 +49,15 @@ def filter_images(image_dir:Path, img_type:str='JPEG')->int:
     nons = 0
     path = Path(image_dir)
     for f in path.iterdir():
-        jpeg = magic.from_file(f.as_posix())[:4]
-        if f.is_file() and jpeg != img_type:
-            nons = nons + 1
-            f.unlink()
+        try: 
+            jpeg = magic.from_file(f.as_posix())[:4]
+            if f.is_file() and jpeg != img_type:
+                nons = nons + 1
+                f.unlink()
+        except: 
+            nons += 1   
+            f.unlink() 
+        
     return nons
 
 def start_crawler(Crawler_class:icrawler, path:Path, search_text:str, num_images:int, file_idx_offset=0):


### PR DESCRIPTION
I've had this error when running filter_images():

`magic.MagicException: b'JPEG image data, Exif standard: [TIFF image data, big-endian, direntries=7, orientation=upper-left, xresolution=98, yresolution=106, resolutionunit=2, software=Adobe Photoshop CC 2019 (Windows), datetime=2019:03:06 11:18:46] name use count (30) exceeded'`

The file is actually okay, but its EXIF is too long, causing exception for some reason. You can either try increasing the limit in magic library (or where it's set) or to handle this as a bad image and just skip it. I went for the second option. 

This way it should just drop the problematic file and continue, instead of terminating the script.