### PR TITLE
[modify] changing the readme for dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ directories. It is largely obsolete due to the new capabilities provided directl
 - `Anaconda` should be installed
 - With `fastai` installed, the dependencies are: `icrawler` and `python-magic`
 - `conda install -c hellock icrawler`
-- `pip install python-magic`
+- `pip install python-magic-bin==0.4.14`
 
 ## Example Usage
 Download up to 500 images of each `class`, check each file to be a valid `jpeg` image, save to directory `dataset`, create imagenet-type directory structure and create `data = ImageDataBunch.from_folder(...)`


### PR DESCRIPTION
python-magic doesn't work for me, and maybe alot of other people as well.
I find I have the same issue as [this](https://github.com/Yelp/elastalert/issues/1927).
I changed python magic to magic-bin which works well. 