### PR TITLE
Improved dedupe_images

### DIFF
--- a/image_download.py
+++ b/image_download.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import hashlib, magic
 import icrawler
 from icrawler.builtin import GoogleImageCrawler, BingImageCrawler, BaiduImageCrawler, FlickrImageCrawler
+from fastai.data.transforms import get_image_files
 # GoogleImageCrawler is not working from icrawler
 
 __all__ = ['dedupe_images','filter_images','image_download','filter_images']
@@ -59,22 +60,11 @@ def start_flickr_crawler(path:Path, search_text:str, n_images:int, apikey:str):
     crawler = FlickrImageCrawler(apikey,feeder_threads=2,parser_threads=2,downloader_threads=8,storage={'root_dir': path})
     crawler.crawl(tags=search_text, max_num=n_images, tag_mode='all')
 
-def dedupe_subfolders_images(dir:Path)->dict:
-    """Delete duplicate images from each dir of a parent dir and returns a dict with
-    duplicated images removed from wach dir"""
-    dirs = {}
-    path = Path(dir)
-    for folder in dir.iterdir():
-      if not folder.name.startswith('.'):
-        dirs[folder.name] = dedupe_images(folder)
-    return dirs
-   
 def dedupe_images(image_dir:Path)->int:
-    """Delete duplicate images from image_dir """
+    """Delete duplicate images from image_dir, also works recursively if there are
+    subfolders containing images"""
     images = {}; dups = []
-    path = Path(image_dir)
-    for f in path.iterdir():
-      if not Path(f).is_dir():
+    for f in get_image_files(image_dir):
         h = hashfile(f)
         if h in images:
             images[h] = images[h] + 1


### PR DESCRIPTION
As I commented earlier, I changed the dedupe_images to work in a more generic way, now deduplicates image files in folder recursively, now it's possible to pass a folder containing subfolders on it, and it still will get only the images and deduplicate it.
The only thing is it needed the get_image_files from fast.data.transforms.